### PR TITLE
Hexadecimal ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ In addition, at least one of these is required:
 * -include-cidr - Include the network in CIDR format
 * -include-range - Include the IP range of the network in string format
 * -include-integer-range - Include the IP range of the network in integer format
+* -include-hex-range - Include the IP range of the network in hexadecimal format
 
 Output
 ======
@@ -40,6 +41,11 @@ are string representations of the first and last IP address in the network.
 
 This adds `network_start_integer` and `network_last_integer` columns. These
 are integer representations of the first and last IP address in the network.
+
+### Integer Range (-include-hex-range)
+
+This adds `network_start_hex` and `network_last_hex` columns. These
+are hexadecimal representations of the first and last IP address in the network.
 
 Copyright and License
 =====================

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -227,6 +227,7 @@ func TestAllOutput(t *testing.T) {
 		true,
 		true,
 		[]interface{}{
+			// nolint: lll
 			"network,network_start_ip,network_last_ip,network_start_integer,network_last_integer,network_start_hex,network_last_hex",
 			"1.0.0.0/24,1.0.0.0,1.0.0.255,16777216,16777471,1000000,10000ff",
 			"4.69.140.16/29,4.69.140.16,4.69.140.23,71666704,71666711,4458c10,4458c17",
@@ -291,6 +292,7 @@ func TestFileWriting(t *testing.T) {
 1.0.0.0/24,"some more"
 `
 
+	// nolint: lll
 	expected := `network,network_start_ip,network_last_ip,network_start_integer,network_last_integer,network_start_hex,network_last_hex,something
 1.0.0.0/24,1.0.0.0,1.0.0.255,16777216,16777471,1000000,10000ff,some more
 `

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	if !*ipRange && !*intRange && !*cidr && !*hexRange {
-		errors = append(errors, "-include-cidr, -include-range, -include-integer-range" +
+		errors = append(errors, "-include-cidr, -include-range, -include-integer-range"+
 			" or -include-hex-range is required")
 	}
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	if !*ipRange && !*intRange && !*cidr && !*hexRange {
-		errors = append(errors, "-include-cidr, -include-range, -include-integer-range"+
+		errors = append(errors, "-include-cidr, -include-range, -include-integer-range,"+
 			" or -include-hex-range is required")
 	}
 

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ func main() {
 	output := flag.String("output-file", "", "The path to the output CSV (REQUIRED)")
 	ipRange := flag.Bool("include-range", false, "Include the IP range of the network in string format")
 	intRange := flag.Bool("include-integer-range", false, "Include the IP range of the network in integer format")
+	hexRange := flag.Bool("include-hex-range", false, "Include the IP range of the network in hexadecimal format")
 	cidr := flag.Bool("include-cidr", false, "Include the network in CIDR format")
 
 	flag.Parse()
@@ -28,8 +29,8 @@ func main() {
 		errors = append(errors, "-output-file is required")
 	}
 
-	if !*ipRange && !*intRange && !*cidr {
-		errors = append(errors, "-include-cidr, -include-range, or -include-integer-range is required")
+	if !*ipRange && !*intRange && !*cidr && !*hexRange {
+		errors = append(errors, "-include-cidr, -include-range, -include-integer-range or -include-hex-range is required")
 	}
 
 	args := flag.Args()
@@ -42,7 +43,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err := convert.ConvertFile(*input, *output, *cidr, *ipRange, *intRange)
+	err := convert.ConvertFile(*input, *output, *cidr, *ipRange, *intRange, *hexRange)
 	if err != nil {
 		fmt.Fprintf(flag.CommandLine.Output(), "Error: %v\n", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -30,7 +30,8 @@ func main() {
 	}
 
 	if !*ipRange && !*intRange && !*cidr && !*hexRange {
-		errors = append(errors, "-include-cidr, -include-range, -include-integer-range or -include-hex-range is required")
+		errors = append(errors, "-include-cidr, -include-range, -include-integer-range" +
+			" or -include-hex-range is required")
 	}
 
 	args := flag.Args()


### PR DESCRIPTION
We load IPV6 file in SQL Server, and we need IPs in a binary format. Using TSQL it is not easy to convert huge decimal integers to binary. It is possible but the performance is not superb. It is much easier to convert IP ranges to binary using this tool, so I added support for one more command-line switch, -include-hex-range. I hope it is helpful.