### PR TITLE
Add an equality check for file I/O names

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,10 @@ func main() {
 		errors = append(errors, "-output-file is required")
 	}
 
+	if *input != "" && *output != "" && *output == *input {
+		errors = append(errors, "Your output file must be different than your block file(input file).")
+	}
+
 	if !*ipRange && !*intRange && !*cidr && !*hexRange {
 		errors = append(errors, "-include-cidr, -include-range, -include-integer-range,"+
 			" or -include-hex-range is required")


### PR DESCRIPTION
Related Issue: #36 

Problem:
When the arguments for the input and the output files are the same, it causes a corruption in the input file. 

The way I solve it:
This PR adds an extra equality check in between the name of the input file and the name of the output file. 