### PR TITLE
Fix golangci-lint build

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,9 +166,6 @@ linters-settings:
       - os.Remove
       - os.RemoveAll
 
-    # This is a workaround for https://github.com/golangci/golangci-lint/issues/4733
-    ignore: ""
-
   errorlint:
     errorf: true
     asserts: true


### PR DESCRIPTION
- **Set min Go version to 1.23. Test on 1.24.**
- **Resyc golangci-lint config and convert to YAML**
- **Remove workaround**
