### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,7 +41,7 @@ nfpms:
     vendor: 'MaxMind, Inc.'
     homepage: 'https://www.maxmind.com/'
     maintainer: 'MaxMind, Inc. <support@maxmind.com>'
-    description: 'Convert GeoIP2 and GeoLite2 CSVs to different formats.'
+    description: 'Convert GeoIP and GeoLite CSVs to different formats.'
     license: 'Apache 2.0'
     formats:
       - 'deb'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## GeoIP2 CSV Format Converter
+## GeoIP CSV Format Converter
 
-This is a simple utility for converting the MaxMind GeoIP2 and GeoLite2 CSVs to
+This is a simple utility for converting the MaxMind GeoIP and GeoLite CSVs to
 different formats for representing IP addresses such as IP ranges or integer
 ranges.
 

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -1,4 +1,4 @@
-// Package convert transforms a GeoIP2/GeoLite2 CSV to various formats.
+// Package convert transforms a GeoIP/GeoLite CSV to various formats.
 package convert
 
 import (
@@ -21,7 +21,7 @@ type (
 	lineFunc   func(netip.Prefix, []string) []string
 )
 
-// ConvertFile converts the MaxMind GeoIP2 or GeoLite2 CSV file `inputFile` to
+// ConvertFile converts the MaxMind GeoIP or GeoLite CSV file `inputFile` to
 // `outputFile` file using a different representation of the network. The
 // representation can be specified by setting one or more of `cidr`,
 // `ipRange`, `intRange` or `hexRange` to true. If none of these are set to true, it will
@@ -66,7 +66,7 @@ func ConvertFile( //nolint: revive // too late to change name
 	return nil
 }
 
-// Convert writes the MaxMind GeoIP2 or GeoLite2 CSV in the `input` io.Reader
+// Convert writes the MaxMind GeoIP or GeoLite CSV in the `input` io.Reader
 // to the Writer `output` using the network representation specified by setting
 // `cidr`, ipRange`, or `intRange` to true. If none of these are set to true,
 // it will strip off the network information.

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
-// geoip2-csv-converter is a utility for converting the MaxMind GeoIP2 and
-// GeoLite2 CSVs to different formats for representing IP addresses such as IP
+// geoip2-csv-converter is a utility for converting the MaxMind GeoIP and
+// GeoLite CSVs to different formats for representing IP addresses such as IP
 // ranges or integer ranges.
 package main
 


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (tool/binary names, edition IDs, filenames, the geolite.info hostname, URLs) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)